### PR TITLE
Fix class keyword in GameView

### DIFF
--- a/main.swift
+++ b/main.swift
@@ -31,7 +31,7 @@ fragment float4 fragment_main(Varying in [[stage_in]]) {
 }
 """
 
-xclass GameView: MTKView, MTKViewDelegate {
+class GameView: MTKView, MTKViewDelegate {
     struct Vertex { var position: SIMD2<Float>; var color: SIMD4<Float> }
     let gridSize = 20
     var snake = [(10,10),(9,10),(8,10)]


### PR DESCRIPTION
## Summary
- correct typo in main.swift that prevented GameView from compiling

## Testing
- `swiftc -sdk "$(xcrun --sdk macosx --show-sdk-path)" -framework Cocoa -framework Metal -framework MetalKit main.swift -o SnakeMetalDemo` *(fails: command not found: xcrun)*

------
https://chatgpt.com/codex/tasks/task_e_6872c7ff16b0832d9504013b3bebc6f2