### PR TITLE
Enable Command-Q exit and snake self-collision

### DIFF
--- a/main.swift
+++ b/main.swift
@@ -58,6 +58,11 @@ class GameView: MTKView, MTKViewDelegate {
         pipeline = try! self.device!.makeRenderPipelineState(descriptor: pd)
 
         NSEvent.addLocalMonitorForEvents(matching: .keyDown) { e in
+            if e.modifierFlags.contains(.command),
+               e.charactersIgnoringModifiers == "q" {
+                NSApp.terminate(nil)
+                return nil
+            }
             switch e.keyCode {
             case 123: self.dir = (-1, 0)
             case 124: self.dir = ( 1, 0)
@@ -87,6 +92,10 @@ class GameView: MTKView, MTKViewDelegate {
                 food = (Int.random(in: 0..<gridSize), Int.random(in: 0..<gridSize))
             } else {
                 snake.removeLast()
+            }
+            if snake.dropFirst().contains(where: { $0 == head }) {
+                NSApp.terminate(nil)
+                return
             }
         }
 


### PR DESCRIPTION
## Summary
- allow quitting with Command+Q
- terminate game when snake collides with itself

## Testing
- `swiftc -sdk "$(xcrun --sdk macosx --show-sdk-path)" -framework Cocoa -framework Metal -framework MetalKit main.swift -o SnakeMetalDemo` *(fails: `xcrun` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872e549496c832dbd9b22720fc48bf0